### PR TITLE
Fix startup error

### DIFF
--- a/src/main/java/io/github/lokka30/phantomeconomy/BaltopUpdater.java
+++ b/src/main/java/io/github/lokka30/phantomeconomy/BaltopUpdater.java
@@ -25,6 +25,9 @@ public class BaltopUpdater {
         try {
             JSONObject jsonObject = (JSONObject) parser.parse(new FileReader(path + "data.json"));
             JSONObject players = (JSONObject) jsonObject.get("players");
+            if(players == null) {
+                return;
+            }
             ArrayList<String> keys = new ArrayList<String>(players.keySet());
             Map<String, Double> updatedTreeMap = new HashMap<>();
 


### PR DESCRIPTION
Fixes #21 
If no players had a balance on the server it'd throw an error when trying to get the balances... cause there wouldn't be any