### PR TITLE
Fix Towny implementation

### DIFF
--- a/src/main/java/io/github/lokka30/phantomeconomy/VaultImplementer.java
+++ b/src/main/java/io/github/lokka30/phantomeconomy/VaultImplementer.java
@@ -414,6 +414,8 @@ public class VaultImplementer implements Economy {
     }
 
     private boolean isTowny(String name) {
-        return (name.startsWith(TownySettings.getTownAccountPrefix()) || name.startsWith(TownySettings.getNationAccountPrefix()));
+        if (Bukkit.getPluginManager().isPluginEnabled("Towny"))
+            return (name.startsWith(TownySettings.getTownAccountPrefix()) || name.startsWith(TownySettings.getNationAccountPrefix()));
+        return false;
     }
 }


### PR DESCRIPTION
While testing on another server without Towny I realized, that we missed to check, if Towny is even installed. With this PR it should be fixed, as we check via #isPluginEnabled(String), if Towny is installed on the server. If it is not, we skip the Towny-related Vault methods and use the more modern ones.

**Without this PR the plugin won't execute any balance-related commands, if Towny isn't installed!**