### PR TITLE
Fix Towny being included in PhantomEconomy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>Towny</artifactId>
             <version>0.96.1.2</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## The issue
The PhantomEconomy JAR (PhantomEconomy-1.9.30-RELEASE.jar as downloaded from spigotmc.org) contains all classes from the Towny plugin.

## How to reproduce
1. Download this file: https://www.spigotmc.org/resources/%E2%99%A6-phantomeconomy-%E2%99%A6-for-1-7-1-16.75053/download?version=339983
2. Open the JAR as a ZIP file. Either rename the .jar file to a .zip file and then open it, or use a program like 7-Zip.
3. Notice that there is a folder `com/palmergames/` inside the file, containing all Towny classes.

## How it was fixed.
In the pom.xml file near [this location](https://github.com/lokka30/PhantomEconomy/blob/c5436ad57aae0fe7fc19b9417aa2bd80611e3f7a/pom.xml#L119), I added `<scope>provided</scope>`. This tells maven-shade-plugin that Towny is already provided, and that it doesn't need to be included.

Note: I was not able to compile the plugin, as the build failed: Maven couldn't automatically download a copy of Towny. So please test this yourself. 😄 

Discovered in https://github.com/rutgerkok/BlockLocker/issues/74